### PR TITLE
Update REAMDE.md due issues #4 #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Since kcfinder package do not have stable release on packagist, you should use t
 After, either run
 
 ```
-php composer.phar require "iutbay/yii2-kcfinder" "*"
+php composer.phar require "iutbay/yii2-kcfinder" "dev-master"
 ```
 
 or add
 
 ```json
-"iutbay/yii2-kcfinder" : "*"
+"iutbay/yii2-kcfinder" : "dev-master"
 ```
 
 to the require section of your application's `composer.json` file.


### PR DESCRIPTION
Because using

```
"iutbay/yii2-kcfinder" : "*"
```

Composer downloaded only 0.0.1 version instead of master branch, which is contains couple of fixes.
